### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/kopiahhaji/quran-learning-platform/security/code-scanning/1](https://github.com/kopiahhaji/quran-learning-platform/security/code-scanning/1)

To fix the issue, we need to explicitly define the permissions for the `build` job. Since the `build` job only requires read access to the repository contents, we can set `contents: read` as the permission. This ensures that the job does not have unnecessary write permissions.

The changes will involve adding a `permissions` block to the `build` job in the `.github/workflows/npm-publish-github-packages.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
